### PR TITLE
Feature/#36: userinfo 폴더 생성, 디자인 틀 완성

### DIFF
--- a/client/src/components/user-info/UserInfo.tsx
+++ b/client/src/components/user-info/UserInfo.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+// import styled from "styled-components";
+import "antd/dist/antd.min.css";
+import { Typography, Form, Input } from "antd";
+import { Button } from "antd";
+
+const { Title } = Typography;
+const onhandleUpadate = (event: React.MouseEvent<HTMLElement>) => {
+  event.preventDefault();
+  console.log("click", event);
+};
+function UserInfo() {
+  return (
+    <div style={{ maxWidth: "700px", margin: "2rem auto" }}>
+      <Title>개인정보</Title>
+      <Form>
+        <Input
+          style={{ marginBottom: "1rem" }}
+          type="text"
+          name="name"
+          value="name"
+        />
+        <Input
+          style={{ marginBottom: "1rem" }}
+          type="text"
+          name="email"
+          value="email"
+          disabled
+        />
+        <div style={{ marginBottom: "1rem" }}>
+          <Input
+            style={{ width: "50%" }}
+            type="text"
+            name="password"
+            value="password"
+          />
+          <Button>확인</Button>
+        </div>
+        <Input
+          style={{ marginBottom: "1rem" }}
+          type="text"
+          name="phone"
+          value="phone"
+        />
+        <div>
+          <div style={{ width: "100%", marginBottom: "1rem" }}>
+            <Input
+              style={{ width: "50%" }}
+              type="text"
+              name="postal"
+              value="postal"
+            />
+            <Button>주소찾기</Button>
+          </div>
+          <Input
+            style={{ marginBottom: "1rem" }}
+            type="text"
+            name="address1"
+            value="address1"
+          />
+          <Input
+            style={{ marginBottom: "1rem" }}
+            type="text"
+            name="address2"
+            value="address2"
+          />
+        </div>
+        <Button onClick={onhandleUpadate}>수정버튼</Button>
+      </Form>
+    </div>
+  );
+}
+
+export default UserInfo;


### PR DESCRIPTION
## 📑 제목
일반 회원 개인 정보 페이지 디자인 틀 완성
<img width="809" alt="스크린샷 2022-07-08 오후 3 17 36" src="https://user-images.githubusercontent.com/82802784/177928924-e8de46d2-a591-4e21-969e-42eecb8b53f7.png">

## 📎 관련 이슈
closes #36

## ✔️ 셀프 체크리스트
- [ v] Warning Message가 발생하지 않았나요?
- [v ] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
antd를 이용해 일반 회원의 개인정보 페이지 디자인 틀을 완성함
 
## 🚧 PR 특이 사항
[[FE] 개인정보 페이지]-[디자인]-[기초 디자인]


## 🕰 실제 소요 시간
0.5h
