### PR TITLE
Feature/#39: 유저 마이페이지 폴더 생성, 디자인 틀 완성

### DIFF
--- a/client/src/components/user-mypage/UserMypage.tsx
+++ b/client/src/components/user-mypage/UserMypage.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import "antd/dist/antd.min.css";
+import styled from "styled-components";
+import { PageHeader } from "antd";
+
+const Container = styled.div`
+  display: flex;
+  width: 100%;
+  padding: 1rem;
+`;
+const Card = styled.div`
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+  border-radius: 10px;
+  width: 33%;
+  padding: 1rem;
+  margin: 0.3rem;
+`;
+
+const CardTitle = styled.div`
+  margin-top: 2rem;
+  margin-bottom: 0.3rem;
+  font-weight: 500;
+`;
+const CardDescription = styled.p`
+  font-size: 13px;
+  color: gray;
+`;
+
+function UserMypage() {
+  return (
+    <div style={{ maxWidth: "700px", margin: "2rem auto" }}>
+      <PageHeader
+        onBack={() => null}
+        title="name님"
+        subTitle="마이페이지에 오신걸 환영합니다"
+      />
+      <Container>
+        <Card>
+          <i className="fa-solid fa-id-card fa-xl"></i>
+          <CardTitle>개인정보</CardTitle>
+          <CardDescription>개인정보를 열람하고 수정합니다.</CardDescription>
+        </Card>
+        <Card>
+          <i className="fa-solid fa-paw fa-xl"></i>
+          <CardTitle>펫 정보</CardTitle>
+          <CardDescription>펫 정보를 열람하고 수정합니다.</CardDescription>
+        </Card>
+        <Card>
+          <i className="fa-solid fa-list-check fa-xl"></i>
+          <CardTitle>예약 내역</CardTitle>
+          <CardDescription>예약 내역을 확인하고 관리합니다.</CardDescription>
+        </Card>
+      </Container>
+    </div>
+  );
+}
+
+export default UserMypage;

--- a/client/src/components/user-mypage/UserMypage.tsx
+++ b/client/src/components/user-mypage/UserMypage.tsx
@@ -14,6 +14,9 @@ const Card = styled.div`
   width: 33%;
   padding: 1rem;
   margin: 0.3rem;
+  :hover {
+    transform: scale(1.01);
+  }
 `;
 
 const CardTitle = styled.div`

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import { GlobalStyle } from './styles/GlobalStyles';
-import { ThemeProvider } from 'styled-components';
-import { theme } from './styles/Colors';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import { GlobalStyle } from "./styles/GlobalStyles";
+import { ThemeProvider } from "styled-components";
+import { theme } from "./styles/Colors";
+import "@fortawesome/fontawesome-free/js/all.js";
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById("root") as HTMLElement
 );
 root.render(
   <ThemeProvider theme={theme}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "Animal-Hospital",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.1.1"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.1.tgz",
+      "integrity": "sha512-J/3yg2AIXc9wznaVqpHVX3Wa5jwKovVF0AMYSnbmcXTiL3PpRPfF58pzWucCwEiCJBp+hCNRLWClTomD8SseKg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-free": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.1.tgz",
+      "integrity": "sha512-J/3yg2AIXc9wznaVqpHVX3Wa5jwKovVF0AMYSnbmcXTiL3PpRPfF58pzWucCwEiCJBp+hCNRLWClTomD8SseKg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.1.1"
+  }
+}


### PR DESCRIPTION
## 📑 제목
일반회원의 마이페이지 디자인 틀 완성
<img width="795" alt="스크린샷 2022-07-08 오후 4 48 25" src="https://user-images.githubusercontent.com/82802784/177943869-8fbf8233-8bfd-48ca-a466-c65af8415484.png">



## 📎 관련 이슈
closes #39 

## ✔️ 셀프 체크리스트
- [v ] Warning Message가 발생하지 않았나요?
- [v] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
일반회원의 마이페이지 디자인 틀을 완성함
 
## 🚧 PR 특이 사항
아이콘을 사용하기위해   npm i @fortawesome/fontawesome-free  로 fontawesome을 설치, index.tsx에 import "@fortawesome/fontawesome-free/js/all.js";를 추가함
<img width="716" alt="스크린샷 2022-07-08 오후 4 51 21" src="https://user-images.githubusercontent.com/82802784/177944359-c8ae1bc0-c2ef-40b7-9c59-4a417f0e431e.png">



[[FE] 유저 마이페이지]-[디자인]-[개인정보, 펫정보, 예약내역 버튼 완성]

## 🕰 실제 소요 시간
1h
