### PR TITLE
feature/#37: pet-info 폴더 생성, 디자인 틀 생성

### DIFF
--- a/client/src/pages/pet-info/PetInfo.tsx
+++ b/client/src/pages/pet-info/PetInfo.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import "antd/dist/antd.min.css";
+import styled from "styled-components";
+import { Button, Form, Input, Typography } from "antd";
+
+const { Title } = Typography;
+
+const buttonHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    alert(
+      '버튼이 클릭되었습니다(확인용)'
+    )
+  };
+
+type PetCard = {
+  image: string,
+  name: string,
+  age: number,
+  sex: string,
+  weight: number,
+  species: string,
+  breed: string,
+  medicalHistory: string,
+  vaccination: string,
+  neutralized: string
+}
+
+PetCard.defaultProps = {
+  image: 'https://cdn.imweb.me/upload/S201712205a3a0910b89f5/d95b7faed6d64.jpg',
+  name: '두식이',
+  age: 3,
+  sex: '',
+  weight: 10.0,
+  species: '',
+  breed: '',
+  medicalHistory: '없음',
+  vaccination: '모름',
+  neutralized: '',
+}
+
+export default function PetCard({
+  image, name, age, weight, species, breed, vaccination, medicalHistory, neutralized
+}: PetCard) {
+  return (
+    <div>
+    <Form style={{ marginLeft: "2rem" }}>
+      <Title>펫 정보</Title>
+      <div style={{ marginBottom: "1rem" }} />
+      <div>
+        <SubTitle>사진</SubTitle>
+        <div style={{ marginBottom: "0.5rem" }} />
+        <div>
+          <img src={image} width="280px" />
+          <Button style={{ marginLeft: "0.5rem" }} onClick={buttonHandler}>수정</Button>
+        </div>
+      </div>
+      <div style={{ marginBottom: "1rem" }} />
+      <div>
+        <SubTitle>이름</SubTitle>
+        <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={name} disabled />
+      </div>
+      <div>
+        <SubTitle>나이</SubTitle>
+        <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={age} disabled />
+      </div>
+      <div>
+        <SubTitle>성별</SubTitle>
+        <label><input style={{ marginLeft: "0.5rem" }} type="radio" name="gender" value="F" />F</label>
+        <label><input style={{ marginLeft: "0.5rem" }} type="radio" name="gender" value="M" />M</label>
+        <div style={{ marginBottom: "1rem" }} />
+      </div>
+      <div>
+        <SubTitle>무게</SubTitle>
+        <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={weight} disabled />
+      </div>
+      <div>
+        <SubTitle>종</SubTitle>
+        <select style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} name="animal" id="animal" disabled>
+            <option value="">선택</option>
+            <option value="개">개</option>
+            <option value="고양이">고양이</option>
+            <option value="기타">기타</option>
+        </select>
+      </div>
+      <div>
+        <SubTitle>병력</SubTitle>
+        <input style={{ marginBottom: "0.5rem", marginLeft: "0.5rem" }} type="text" value={medicalHistory} disabled />
+      </div>
+      <div>
+        <SubTitle>접종이력</SubTitle>
+        <input style={{ marginBottom: "0.5rem", marginLeft: "0.5rem" }} type="text" value={vaccination} disabled />
+      </div>
+      <div>
+        <SubTitle>중성화 수술 여부</SubTitle>
+        <label><input style={{ marginLeft: "0.5rem" }} type="radio" name="tcr" value="완료" />완료</label>
+        <label><input style={{ marginLeft: "0.5rem" }} type="radio" name="tcr" value="미완료" />미완료</label>
+        <label><input style={{ marginLeft: "0.5rem" }} type="radio" name="tcr" value="모름" />모름</label>
+      </div>
+      <Button style={{ marginTop: "1rem" }} onClick={buttonHandler}>수정</Button>
+    </Form>
+    </div>
+  );
+}
+
+const SubTitle = styled.span`
+  font-size: 16px;
+`


### PR DESCRIPTION
## 📑 제목
펫 정보 페이지 `pet-info` 폴더 생성하여 작성하였습니다.

![image](https://user-images.githubusercontent.com/49031232/177947664-cb336aa5-cb30-4b34-aa8a-fb871d755372.png)

## 📎 관련 이슈
closes #37 

## ✔️ 셀프 체크리스트
- [v] Warning Message가 발생하지 않았나요?
- [v] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
펫 정보 페이지(`pet-info`-`PetInfo.tsx`) 작성했습니다.
- 기본적으로 `input` 들은 `disabled` 상태입니다.
- `defaultProps` 설정하여 임의의 `두식이`라는 고양이 데이터가 뜨도록 했습니다.
- 편의를 위해 `버튼 작동 여부` 확인 위해 클릭 시 버튼 클릭을 확인하는 alert가 뜨도록 했습니다. 
 
![image](https://user-images.githubusercontent.com/49031232/177948473-a75f401c-92f2-4d4b-9e6a-84ebb7d2f1f2.png)

## 🚧 PR 특이 사항

[[FE] 펫 정보 페이지]-[디자인]-[기초 디자인]

## 🕰 실제 소요 시간
3(시간)
