### PR TITLE
feature/#89: 회원가입 API 연동 후 토큰을 로컬스토리지에 저장

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10793,8 +10793,7 @@
     "react-daum-postcode": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.1.tgz",
-      "integrity": "sha512-IFlC8XBSK+uobSIBHaWlxeecYpv9RhCFNu4YJ3+CrfGyEVdc4+yaaUH6BIfJbTZOybVx0V3s4nUeAEsssXBNJg==",
-      "requires": {}
+      "integrity": "sha512-IFlC8XBSK+uobSIBHaWlxeecYpv9RhCFNu4YJ3+CrfGyEVdc4+yaaUH6BIfJbTZOybVx0V3s4nUeAEsssXBNJg=="
     },
     "react-dev-utils": {
       "version": "12.0.1",

--- a/client/src/pages/login/LoginLayout.tsx
+++ b/client/src/pages/login/LoginLayout.tsx
@@ -38,12 +38,30 @@ function LoginLayout() {
     });
   };
 
-  const handleLoginChecked = (e: React.MouseEvent<HTMLElement>) => {
+  const handleLoginChecked = async (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
-    console.log(logins);
 
-    // 로그인 버튼 클릭시에 입력한 이메일을 기준으로 백엔드에서 데이터를 찾고 그 이메일을 기준으로 password까지 확인해서 맞으면 pass시키고 틀리면 fail 시킨다.
-    axios.get('유저 정보 url 접근').then((res) => console.log(res));
+    try {
+      const result = await axios.post(
+        'http://localhost:5100/api/login',
+        JSON.stringify(logins),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      const token: string = result.data.userToken.token;
+      // 만일 토큰이 존재하면 로그인에 성공한거니까 access 토큰을 storage에 저장한후에 로그인 성공 메시지 남기고 페이지 이동
+      if (token) {
+        localStorage.setItem('token', token);
+        alert('로그인 성공하셨습니다.');
+        window.location.href = '/';
+      }
+    } catch (e) {
+      console.log(e);
+      alert('아이디 또는 비밀번호 오류입니다.');
+    }
   };
 
   return (
@@ -61,6 +79,7 @@ function LoginLayout() {
           sx={{ mb: 1 }}
         />
         <PasswordInput
+          type="password"
           name="password"
           value={password}
           onChange={handleLoginState}

--- a/client/src/pages/login/LoginStyle.tsx
+++ b/client/src/pages/login/LoginStyle.tsx
@@ -11,7 +11,7 @@ const LoginTitle = styled.h3`
 
 // Login을 둘러싸고 있는 Wrapper
 const LoginWrapper = styled.div`
-  width: 340px;
+  width: 550px;
   position: absolute;
   left: 50%;
   top: 50%;


### PR DESCRIPTION
## 📑 제목
회원가입 API 연동 후에 액세스 토큰을 로컬스토리지에 저장 

## 📎 관련 이슈
closes #89 

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
회원가입 API 연동 후에 액세스 토큰을 로컬스토리지에 저장하였습니다. 

 
## 🚧 PR 특이 사항
+ 코드 충돌 방지를 위해 cors에러가 나서 백엔드 코드를 수정했던 부분을 다시 돌려놨습니다.  

[[FE] 로그인 화면]-[Validation]-[로그인 폼(이메일 / 비밀번호)]
[[FE] 로그인 화면]-[API 요청]- [로그인 요청 후 토큰 저장]

## 🕰 실제 소요 시간
12h
