### PR TITLE
Feature/#90: 병원 스키마 적용, 폼 저장 시 데이터 생성

### DIFF
--- a/client/src/pages/hospital-info/HospitalInfo.tsx
+++ b/client/src/pages/hospital-info/HospitalInfo.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import "antd/dist/antd.min.css";
 import styled from "styled-components";
 import { Button, Form, Input, Typography } from "antd";
+import { theme } from '../../styles/Colors';
 
 import axios from "axios";
 
@@ -198,16 +199,19 @@ export default function HospitalCard() {
         <div>
           <SubTitle>병원 사진</SubTitle>
           <div style={{ marginBottom: "0.5rem" }} />
+          <div style={{ marginBottom: "0.5rem" }}>
+            <UploadFileLabel htmlFor="uploadFile">업로드</UploadFileLabel>
+            <UploadFileInput type="file"
+              id="uploadFile"
+              accept='image/jpg,image/png,image/jpeg,image/gif'
+              name='profile_img'
+              onChange={(e: any) => {
+                convertFileToBase64(e.target.files[0]);
+                console.log(e.target.files);
+              }}
+            />
+          </div>
           <div>
-            <div>
-              <input type="file"
-                accept='image/jpg,image/png,image/jpeg,image/gif'
-                name='profile_img'
-                onChange={(e: any) => {
-                  convertFileToBase64(e.target.files[0]);
-                }}
-              />
-            </div>
             {image && <img src={image} width="280px" alt="" />}
           </div>
         </div>
@@ -275,4 +279,27 @@ export default function HospitalCard() {
 
 const SubTitle = styled.span`
   font-size: 16px;
+`
+const UploadFileLabel = styled.label`
+  display: inline-block;
+  padding: .5em .8em;
+  font-size: inherit;
+  line-height: normal;
+  vertical-align: middle;
+  cursor: pointer;
+  border: 1px solid ${theme.palette.lightgray};
+  border-radius: .25em;
+
+  :hover {
+    transition: 2ms ease-in;
+    border-color: ${theme.palette.blue};
+    color: ${theme.palette.blue};
+  }
+`
+const UploadFileInput = styled.input`
+  position: absolute;
+  padding: 0;
+  margin: -1px;
+  clip:rect(0,0,0,0);
+  border: 0;
 `

--- a/client/src/pages/hospital-info/HospitalInfo.tsx
+++ b/client/src/pages/hospital-info/HospitalInfo.tsx
@@ -1,61 +1,113 @@
-import React from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import "antd/dist/antd.min.css";
 import styled from "styled-components";
-import { Button, Form, Input, Typography } from "antd";
+import { Button, Form, Typography } from "antd";
+import axios from "axios";
 
 const { Title } = Typography;
 
-const buttonHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
-  event.preventDefault();
-  alert(
-    '사진 수정 버튼이 클릭되었습니다(확인용)'
-  )
-};
-
-const editButtonHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
-  event.preventDefault();
-  alert('병원 정보들 수정 버튼이 클릭되었습니다(확인용)')
+// 임시 데이터 (삭제 예정)
+const jsonData = {
+  "name": "이이진진수수 동동물물병병원원",
+  "email": "sarangS2hospital@gmail.com",
+  "director": "이진수",
+  "password": "12345",
+  "address": {
+    "postalCode": "13477",
+    "address1": "경기 성남시 분당구 판교공원로5길 15",
+    "address2": "이진수 동물병원"
+  },
+  "phoneNumber": "010-0000-0000",
+  "businessHours": "24시간",
+  "businessNumber": "XXXXXXXXX",
+  "licenseNumber": "XXXXXXXXX",
+  "holiday": [""],
+  "hospitalCapacity": 3,
+  "tag": [""],
+  "keyword": [""],
+  "image": "https://o-oa.com/wp-content/uploads/2020/05/LJS_01.jpg",
+  "refreshToken": undefined,
+  "hospStatus": "정상",
+  "hospRegStatus": "승인완료"
 }
 
-// 임의 타입 지정. 백엔드에서 병원 스키마 완성되면 명칭 수정할 예정.
-type HospitalCard = {
-  hospitalName: string,
-  doctorName: string,
-  email: string,
-  password: string,
-  phoneNumber: number,
-  tradersNumber: string,
-  licenseNumber: string,
-  image: string,
-  postalNumber: number,
-  address1: string,
-  address2: string,
-  categories: string,
-  keywords: Array<string>,
-  openingHours: string,
-  customersPerHours: number
-}
+export default function HospitalCard() {
+  // const [datas, setDatas] = useState<[]>([]);
+  // 병원 api 생기면 주석 풀고 나머지 작성 예정
+  // const API_URL = `http://localhost:5100/api/hospitals`;
 
-// 임의 데이터 지정. 마찬가지로 수정 예정.
-HospitalCard.defaultProps = {
-  hospitalName: '이이진진수수 동동물물병병원원',
-  doctorName: '김진수',
-  email: 'sarangS2hospital@gmail.com',
-  password: '',
-  phoneNumber: '010-0000-0000',
-  tradersNumber: 'XXXXXXXXX',
-  licenseNumber: 'XXXXXXXXX',
-  image: 'https://o-oa.com/wp-content/uploads/2020/05/LJS_01.jpg',
-  postalNumber: 13477,
-  address1: '경기 성남시 분당구 판교공원로5길 15',
-  address2: '이진수 동물병원',
-  categories: '병원',
-  keywords: [],
-  openingHours: '24시간',
-  customersPerHours: 3
-}
+  // useEffect(() => {
+  //   if (datas.length) console.log(datas);
+  // }, [datas]);
 
-export default function HospitalCard({hospitalName, doctorName, email, password, phoneNumber, tradersNumber, licenseNumber, image, postalNumber, address1, address2, categories, keywords, openingHours, customersPerHours}: HospitalCard) {
+  // const getAPI = useCallback(
+  //   async (e: any) => {
+  //     e.preventDefault();
+  //     const result = await axios.get(API_URL);
+  //     console.log("result.data: ", result.data);
+  //   },
+  //   [API_URL]
+  // );
+  // validation 시 e.target.value를 바로 비교하면 밀리지 않게 바로바로 비교 가능
+  const [name, setName] = useState(jsonData.name);
+  const [director, setDirector] = useState(jsonData.director);
+  const [phoneNumber, setPhoneNumber] = useState(jsonData.phoneNumber);
+  const [businessHours, setBusinessHours] = useState(jsonData.businessHours);
+  const [businessNumber, setBusinessNumber] = useState(jsonData.businessNumber);
+  const [licenseNumber, setLicenseNumber] = useState(jsonData.licenseNumber);
+  const [holiday, setHoliday] = useState(jsonData.holiday);
+  const [hospitalCapacity, setHospitalCapacity] = useState(jsonData.hospitalCapacity);
+  const [tag, setTag] = useState(jsonData.tag);
+  const [keyword, setKeyWord] = useState(jsonData.keyword);
+  const [image, setImage] = useState(jsonData.image);
+  // refreshToken 등 추가 예정
+  const [hospStatus, setHospStatus] = useState(jsonData.hospStatus);
+  const [hospRegStatus, setHospRegStatus] = useState(jsonData.hospRegStatus);
+  const [address, setAddress] = useState();
+
+  const { postalCode, address1, address2 } = jsonData.address;
+  const email = jsonData.email;
+
+  const onChangeName = (e: any) => {
+    setName(e.target.value);
+    // api가 없어서 실제 수정이 반영되지는 않음. 백에서 완성한 이후 추가 예정
+    console.log("이름 변경:", e.target.value);
+  }
+  const onChangeDirector = (e: any) => {
+    setDirector(e.target.value);
+    console.log("대표자명 변경:", e.target.value);
+  }
+  const onChangePhoneNumber = (e: any) => {
+    setPhoneNumber(e.target.value);
+    console.log("연락처 변경:", e.target.value);
+  }
+  const onChangeLicenseNumber = (e: any) => {
+    setPhoneNumber(e.target.value);
+    console.log("면허번호 변경:", e.target.value);
+  }
+
+  const onChangeHospitalCapacity = (e: any) => {
+    setHospitalCapacity(e.target.value);
+    console.log("시간당 예약 가능 고객 수 변경:", e.target.value);
+  }
+  const onChangeBusinessNumber = (e: any) => {
+    setBusinessNumber(e.target.value);
+    console.log("사업자 등록번호 변경:", e.target.value);
+  }
+  // e.state.value
+
+  const buttonHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    alert(
+      '버튼이 클릭되었습니다(확인용)'
+    )
+  };
+  
+  const withdrawButtonHandler = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    alert('병원 회원 탈퇴 버튼이 클릭되었습니다(확인용)')
+  }
+
   return (
     <div>
       <Form style={{ marginLeft: "2rem" }}>
@@ -63,64 +115,140 @@ export default function HospitalCard({hospitalName, doctorName, email, password,
         <div style={{ marginBottom: "1rem" }} />
         <div>
           <SubTitle>병원명</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={hospitalName} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text"
+            defaultValue={name}
+            onChange={onChangeName}
+          />
         </div>
         <div>
           <SubTitle>이름</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={doctorName} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={director}
+            onChange={onChangeDirector}
+          />
         </div>
         <div>
           <SubTitle>이메일</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={email} disabled />
+          <input style={{
+            marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            value={email}
+            autoComplete="username"
+            disabled
+          />
         </div>
         <div>
           <SubTitle>비밀번호</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={password} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="password"
+            autoComplete="current-password"
+            defaultValue=""
+            disabled
+          />
+          <Button
+              style={{ marginLeft: "0.5rem" }}
+              onClick={buttonHandler}
+            >변경</Button>
         </div>
         <div>
           <SubTitle>병원 연락처</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={phoneNumber} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={phoneNumber}
+            onChange={onChangePhoneNumber}
+          />
         </div>
         <div>
           <SubTitle>사업자 등록번호</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={tradersNumber} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={businessNumber}
+            onChange={onChangeBusinessNumber}
+          />
         </div>
         <div>
           <SubTitle>면허번호</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={licenseNumber} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={licenseNumber}
+            onChange={onChangeLicenseNumber}
+          />
         </div>
         <div>
           <SubTitle>병원 사진</SubTitle>
           <div style={{ marginBottom: "0.5rem" }} />
           <div>
             <img src={image} width="280px" alt="" />
-            <Button style={{ marginLeft: "0.5rem" }} onClick={buttonHandler}>수정</Button>
+            <Button
+              style={{ marginLeft: "0.5rem" }}
+              onClick={buttonHandler}
+            >수정</Button>
           </div>
         </div>
         <div style={{ marginBottom: "0.5rem" }} />
         <div>
           <SubTitle>주소</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={postalNumber} disabled />
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={address1} disabled />
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={address2} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={postalCode}
+          />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={address1}
+          />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={address2}
+          />
+          <Button style={{ marginLeft: "0.5rem" }}>수정</Button>
         </div>
         <div>
           <SubTitle>카테고리</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={categories} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={tag}
+          />
         </div>
         <div>
           <SubTitle>키워드</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={keywords} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={keyword}
+          />
         </div>
         <div>
           <SubTitle>영업시간</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={openingHours} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={businessHours}
+          />
         </div>
         <div>
           <SubTitle>시간당 예약가능 고객 수</SubTitle>
-          <input style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} type="text" value={customersPerHours} disabled />
+          <input
+            style={{ marginBottom: "1rem", marginLeft: "0.5rem" }} 
+            type="text"
+            defaultValue={hospitalCapacity}
+            onChange={onChangeHospitalCapacity}
+          />
         </div>
-        <Button onClick={editButtonHandler}>수정</Button>
+        <Button 
+          style={{ marginLeft: "1rem" }}
+          onClick={withdrawButtonHandler}
+        >탈퇴</Button>
       </Form>
     </div>
   );

--- a/client/src/pages/hospital-info/HospitalInfo.tsx
+++ b/client/src/pages/hospital-info/HospitalInfo.tsx
@@ -201,7 +201,7 @@ export default function HospitalCard() {
           <div>
             <div>
               <input type="file"
-                accept='image/jpg,impge/png,image/jpeg,image/gif'
+                accept='image/jpg,image/png,image/jpeg,image/gif'
                 name='profile_img'
                 onChange={(e: any) => {
                   convertFileToBase64(e.target.files[0]);

--- a/client/src/pages/hospital-info/HospitalInfo.tsx
+++ b/client/src/pages/hospital-info/HospitalInfo.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import "antd/dist/antd.min.css";
 import styled from "styled-components";
-import { Button, Form, Typography } from "antd";
+import { Button, Form, Input, Typography } from "antd";
+
 import axios from "axios";
 
 const { Title } = Typography;
@@ -25,7 +26,8 @@ const jsonData = {
   "hospitalCapacity": 3,
   "tag": [""],
   "keyword": [""],
-  "image": "https://o-oa.com/wp-content/uploads/2020/05/LJS_01.jpg",
+  // "image": "https://o-oa.com/wp-content/uploads/2020/05/LJS_01.jpg",
+  "image": "",
   "refreshToken": undefined,
   "hospStatus": "정상",
   "hospRegStatus": "승인완료"
@@ -68,6 +70,19 @@ export default function HospitalCard() {
   const { postalCode, address1, address2 } = jsonData.address;
   const email = jsonData.email;
 
+  const convertFileToBase64 = (file: any) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    return new Promise((resolve: any) => {
+      if (reader) {
+        reader.onload = () => {
+        setImage(reader.result as string);
+        resolve();
+        };
+      }
+    });
+  };
+
   const onChangeName = (e: any) => {
     setName(e.target.value);
     // api가 없어서 실제 수정이 반영되지는 않음. 백에서 완성한 이후 추가 예정
@@ -85,7 +100,6 @@ export default function HospitalCard() {
     setPhoneNumber(e.target.value);
     console.log("면허번호 변경:", e.target.value);
   }
-
   const onChangeHospitalCapacity = (e: any) => {
     setHospitalCapacity(e.target.value);
     console.log("시간당 예약 가능 고객 수 변경:", e.target.value);
@@ -185,11 +199,16 @@ export default function HospitalCard() {
           <SubTitle>병원 사진</SubTitle>
           <div style={{ marginBottom: "0.5rem" }} />
           <div>
-            <img src={image} width="280px" alt="" />
-            <Button
-              style={{ marginLeft: "0.5rem" }}
-              onClick={buttonHandler}
-            >수정</Button>
+            <div>
+              <input type="file"
+                accept='image/jpg,impge/png,image/jpeg,image/gif'
+                name='profile_img'
+                onChange={(e: any) => {
+                  convertFileToBase64(e.target.files[0]);
+                }}
+              />
+            </div>
+            {image && <img src={image} width="280px" alt="" />}
           </div>
         </div>
         <div style={{ marginBottom: "0.5rem" }} />


### PR DESCRIPTION
## 📑 제목
병원 스키마 적용, 폼 저장 시 데이터 생성

![2022-07-13 00;22;27](https://user-images.githubusercontent.com/49031232/178527015-2580dcc3-03d9-448b-82be-53be85b3c6d4.gif)

## 📎 관련 이슈
closes #90

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
- 병원 페이지의 병원 스키마 명 수정
- ~~폼 저장 시 스키마에 맞게 데이터 생성~~ => state를 사용한 데이터 변화, 사진 첨부 기능 구현
- 저장 버튼을 누를 필요 없이 state에 따라 수정내용을 바로 저장하자는 지민님의 의견을 참고해 관련된 요소들에 state를 생성
-  사진 첨부 기능 구현 
- 키워드 부분도 버튼 클릭하지 않고 엔터키로 추가되도록 내일 구현해볼 예정입니다.
- `업로드` 버튼은 css 수정이 불가능한 `<input type="file">` 태그 특성상 따로 생성하여 디자인했고, ant design이 적용되어 있지 않습니다. 수작업으로 디자인해서 이후 디자인 변경 시 함께 변경해주어야 됩니다.

## 🚧 PR 특이 사항
- 폼 저장 시 데이터가 생성되는 부분은 적어뒀으나 병원 정보 수정 라우터가 완성되면 실제 데이터를 이용해서 api로 백에 반영하는 부분까지 한 번에 진행하는 편이 더 매끄러울 것 같아서 다른 밑작업들을 했습니다.

[[FE] 내 병원 정보 페이지]-[메인 컴포넌트]-[스키마 적용, 폼 저장 시 데이터 생성]

## 🕰 실제 소요 시간
13(시간)
