### PR TITLE
feature/#137 상세페이지 디자인 틀 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,30 +1,33 @@
-import React from 'react';
-import {Routes, BrowserRouter, Route} from 'react-router-dom';
+import React from "react";
+import { Routes, BrowserRouter, Route } from "react-router-dom";
 
-import Login from './pages/login/LoginLayout';
-import Register from './pages/register/Register';
-import UserMypage from './pages/user-mypage/UserMypage';
-import UserInfo from './pages/user-info/UserInfo';
-import PetInfo from './pages/pet-info/PetInfo';
-import HospitalMypage from './pages/hospital-mypage/HospitalMypage';
-import HospitalInfo from './pages/hospital-info/HospitalInfo';
-import AdminMypage from './pages/admin-mypage/AdminMypage';
-
+import Login from "./pages/login/LoginLayout";
+import Register from "./pages/register/Register";
+import UserMypage from "./pages/user-mypage/UserMypage";
+import UserInfo from "./pages/user-info/UserInfo";
+import PetInfo from "./pages/pet-info/PetInfo";
+import HospitalMypage from "./pages/hospital-mypage/HospitalMypage";
+import HospitalInfo from "./pages/hospital-info/HospitalInfo";
+import AdminMypage from "./pages/admin-mypage/AdminMypage";
+import Detail from "./pages/detail/Detail";
 
 function App() {
-  return <BrowserRouter>
-    <Routes>
-      {/* <Route path='/' element={< />} />  */}
-      <Route path='/login' element={<Login/>} />
-      <Route path='/register' element={<Register />} />
-      <Route path='/user-mypage' element={<UserMypage />} />
-      <Route path='/user-info' element={<UserInfo />} />
-      <Route path='/pet-info' element={<PetInfo />} />
-      <Route path='/hospital-mypage' element={<HospitalMypage />} />
-      <Route path='/hospital-info' element={<HospitalInfo />} />
-      <Route path='/admin-mypage' element={<AdminMypage />} />
-    </Routes>
-  </BrowserRouter>;
+  return (
+    <BrowserRouter>
+      <Routes>
+        {/* <Route path='/' element={< />} />  */}
+        <Route path="/login" element={<Login />} />
+        <Route path="/register" element={<Register />} />
+        <Route path="/user-mypage" element={<UserMypage />} />
+        <Route path="/user-info" element={<UserInfo />} />
+        <Route path="/pet-info" element={<PetInfo />} />
+        <Route path="/hospital-mypage" element={<HospitalMypage />} />
+        <Route path="/hospital-info" element={<HospitalInfo />} />
+        <Route path="/admin-mypage" element={<AdminMypage />} />
+        <Route path="/detail" element={<Detail />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/client/src/pages/detail/Calendar.tsx
+++ b/client/src/pages/detail/Calendar.tsx
@@ -1,0 +1,7 @@
+import React, { useState } from "react";
+
+const CalenderUi = () => {
+  const [value, onChange] = useState(new Date());
+  return <div>calendar</div>;
+};
+export default CalenderUi;

--- a/client/src/pages/detail/Detail.tsx
+++ b/client/src/pages/detail/Detail.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import styled from "styled-components";
+import CalendarUi from "./Calendar";
+const MainContainer = styled.div`
+  max-width: 1000px;
+  margin: 1rem auto;
+`;
+const Header = styled.div`
+  margin: 24px 0;
+`;
+const ImgContainer = styled.div`
+  display: flex;
+  cursor: pointer;
+  /* border: 1px solid; */
+`;
+const MainImg = styled.img`
+  border-top-left-radius: 10px;
+  border-bottom-left-radius: 10px;
+`;
+const RightTopImg = styled.img`
+  border-top-right-radius: 10px;
+  width: 320px;
+  height: 50%;
+`;
+const RightBottomImg = styled.img`
+  border-bottom-right-radius: 10px;
+  width: 320px;
+`;
+const ContentContainer = styled.div`
+  display: flex;
+`;
+const InfoContainer = styled.div`
+  flex: 0 0 60%;
+`;
+const ReservationContainer = styled.div`
+  padding: 1rem;
+  flex: 0 0 40%;
+`;
+const InfoDiv = styled.div`
+  padding-top: 48px;
+  padding-bottom: 24px;
+  border-bottom: 2px ${(props) => props.theme.palette.lightgray} solid;
+`;
+const MainInfo = styled.div`
+  padding-top: 32px;
+  padding-bottom: 32px;
+  border-bottom: 2px ${(props) => props.theme.palette.lightgray} solid;
+`;
+const ReviewContainer = styled.div`
+  padding-top: 32px;
+  padding-bottom: 32px;
+  border-bottom: 2px ${(props) => props.theme.palette.lightgray} solid;
+`;
+const Reservation = styled.div`
+  border: 1px solid rgb(221, 221, 221);
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: rgb(0 0 0 / 12%) 0px 6px 16px;
+`;
+
+function Detail() {
+  return (
+    <MainContainer>
+      <Header>
+        <h1>병원 이름</h1>
+        <p>Address: 1678 Nambusunhwan-ro, Sillim-dong, Gwanak-gu, Seoul</p>
+      </Header>
+      <ImgContainer>
+        <MainImg
+          src="http://www.designtwoply.com/wp-content/uploads/2019/09/designtwoply0000.jpg"
+          alt="img"
+        />
+        <div>
+          <RightTopImg
+            src="http://www.designtwoply.com/wp-content/uploads/2019/09/designtwoply-project-126-4.jpg"
+            alt="img"
+          />
+          <RightBottomImg
+            src="http://www.designtwoply.com/wp-content/uploads/2019/09/designtwoply-project-126-5.jpg"
+            alt="img"
+          />
+        </div>
+      </ImgContainer>
+      <ContentContainer>
+        <InfoContainer>
+          <InfoDiv>
+            <h2>병원 이름</h2>
+            <p>카테고리들</p>
+          </InfoDiv>
+          <MainInfo>
+            <div>키워드들</div>
+            <div>수술, 미용, 진료 등</div>
+          </MainInfo>
+          <ReviewContainer>
+            <h3>Review!</h3>
+          </ReviewContainer>
+        </InfoContainer>
+        <ReservationContainer>
+          <Reservation>
+            예약
+            <CalendarUi />
+          </Reservation>
+        </ReservationContainer>
+      </ContentContainer>
+    </MainContainer>
+  );
+}
+
+export default Detail;


### PR DESCRIPTION
## 📑 제목
상세 페이지 디자인 틀 구현
<img width="1063" alt="스크린샷 2022-07-15 오전 10 55 56" src="https://user-images.githubusercontent.com/82802784/179131285-9f8f132f-62ac-496c-b06c-b45c10e100d4.png">
키워드들 아래 이런 형식으로 서비스명 - 가격 - 서비스 설명이 들어갈 예정입니다!
<img width="702" alt="스크린샷 2022-07-15 오전 11 05 53" src="https://user-images.githubusercontent.com/82802784/179132259-d87903d5-5236-4693-afbd-20b29e58ab73.png">

## 📎 관련 이슈
closes #137

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
상세 페이지 디자인 틀 구현
현재 styled components도 같은 파일에 있지만 추후 분히할 예정입니다.

## 🚧 PR 특이 사항
다음 작업을 위해 머지 진행하겠습니다.

[[FE]상세 페이지]-[디자인]-[기초 디자인 구성]

## 🕰 실제 소요 시간
3h
