### PR TITLE
feature/#165 펫 정보 디자인 틀 재구성

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import Home from "./pages/home/Home";
 import AdminUserList from "./pages/admin-userlist/AdminUserList";
 import Detail from "./pages/detail/Detail";
 import AdminHospitalList from "./pages/admin-hplist/AdminHospitalList";
+import PetInformation from "./pages/pet-information/PetInformation";
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
         <Route path="/register" element={<Register />} />
         <Route path="/user-mypage" element={<UserMypage />} />
         <Route path="/user-info" element={<UserInfo />} />
+        <Route path="/petinfo" element={<PetInformation />} />
         <Route path="/pet-info" element={<PetInfo />} />
         <Route path="/hospital-mypage" element={<HospitalMypage />} />
         <Route path="/hospital-info" element={<HospitalInfo />} />

--- a/client/src/pages/pet-information/AddPet.tsx
+++ b/client/src/pages/pet-information/AddPet.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+function AddPet() {
+  return <div>AddPet</div>;
+}
+
+export default AddPet;

--- a/client/src/pages/pet-information/PetCard.tsx
+++ b/client/src/pages/pet-information/PetCard.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from "react";
+import {
+  PetCardContainer,
+  DeleteBtn,
+  ImgContainer,
+  InfoContainer,
+  InfoInput,
+  InfoTextarea,
+  NameInput,
+  RadioButton,
+  RadioButtonLabel,
+  RadioContainer,
+  RadioText,
+  Item,
+  PetImg,
+  Contents,
+} from "./PetInfoStyle";
+function PetCard() {
+  const [select, setSelect] = useState("F");
+
+  const handleSelectChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setSelect(value);
+  };
+  return (
+    <PetCardContainer>
+      <DeleteBtn>
+        <i className="fa-solid fa-circle-minus fa-xl"></i>
+      </DeleteBtn>
+      <Contents>
+        <ImgContainer>
+          <PetImg src="https://media.istockphoto.com/photos/crazy-looking-black-and-white-border-collie-dog-say-looking-intently-picture-id1213516345?k=20&m=1213516345&s=612x612&w=0&h=_XUSwcrXe5HjI2QEby0ex6Tl1fB_YJUzUU8o2cUt0YA=" />
+        </ImgContainer>
+        <InfoContainer>
+          <NameInput value="Name" />
+          <Contents>
+            <InfoInput value="species" />
+            <InfoInput value="breed" />
+          </Contents>
+          <InfoInput value="age" />
+          <InfoInput value="weight" />
+          <Contents>
+            <Item>
+              <RadioText>성별</RadioText>
+            </Item>
+            <RadioContainer>
+              <Item>
+                <RadioButton
+                  type="radio"
+                  name="gender"
+                  value="F"
+                  checked={select === "F"}
+                  onChange={(event) => handleSelectChange(event)}
+                />
+                <RadioButtonLabel />
+                <RadioText>F</RadioText>
+              </Item>
+              <Item>
+                <RadioButton
+                  type="radio"
+                  name="gender"
+                  value="M"
+                  checked={select === "M"}
+                  onChange={(event) => handleSelectChange(event)}
+                />
+                <RadioButtonLabel />
+                <RadioText>M</RadioText>
+              </Item>
+            </RadioContainer>
+          </Contents>
+          <Contents>
+            <Item>
+              <RadioText>중성화</RadioText>
+            </Item>
+            <RadioContainer>
+              <Item>
+                <RadioButton
+                  type="radio"
+                  name="gender"
+                  value="완료"
+                  checked={select === "완료"}
+                  onChange={(event) => handleSelectChange(event)}
+                />
+                <RadioButtonLabel />
+                <RadioText>완료</RadioText>
+              </Item>
+              <Item>
+                <RadioButton
+                  type="radio"
+                  name="gender"
+                  value="미완료"
+                  checked={select === "미완료"}
+                  onChange={(event) => handleSelectChange(event)}
+                />
+                <RadioButtonLabel />
+                <RadioText>미완료</RadioText>
+              </Item>
+              <Item>
+                <RadioButton
+                  type="radio"
+                  name="gender"
+                  value="모름"
+                  checked={select === "모름"}
+                  onChange={(event) => handleSelectChange(event)}
+                />
+                <RadioButtonLabel />
+                <RadioText>모름</RadioText>
+              </Item>
+            </RadioContainer>
+          </Contents>
+          <InfoTextarea value="medicalHistorys" />
+          <InfoTextarea value="vaccination" />
+          {/* <Btn>
+        <i className="fa-solid fa-paw"></i>
+      </Btn> */}
+        </InfoContainer>
+      </Contents>
+    </PetCardContainer>
+  );
+}
+
+export default PetCard;

--- a/client/src/pages/pet-information/PetInfoStyle.tsx
+++ b/client/src/pages/pet-information/PetInfoStyle.tsx
@@ -1,0 +1,104 @@
+import styled from "styled-components";
+export const MainContainer = styled.div`
+  max-width: 800px;
+  margin: 1rem auto;
+`;
+
+export const AddBtn = styled.button`
+  border: none;
+  border-radius: 50%;
+  padding: 0.3rem 0.5rem;
+  color: ${(props) => props.theme.palette.orange};
+  background-color: ${(props) => props.theme.palette.lightgray};
+  &:hover {
+    background-color: ${(props) => props.theme.palette.orange};
+    color: ${(props) => props.theme.palette.lightgray};
+  }
+`;
+export const PetCardContainer = styled.div`
+  padding: 1rem;
+  border-bottom: 2px ${(props) => props.theme.palette.lightgray} solid;
+`;
+export const DeleteBtn = styled.button`
+  border: none;
+  background: none;
+  display: flex;
+  margin-left: auto;
+  color: ${(props) => props.theme.palette.orange};
+  &:hover {
+    color: ${(props) => props.theme.palette.lightgray};
+  }
+`;
+export const Contents = styled.div`
+  display: flex;
+`;
+export const ImgContainer = styled.div`
+  display: flex;
+  cursor: pointer;
+  /* border: 1px solid; */
+`;
+export const PetImg = styled.img`
+  max-width: 400px;
+  max-height: 300px;
+  border-radius: 15px;
+`;
+
+export const InfoContainer = styled.div`
+  padding: 0 1rem;
+`;
+export const InfoInput = styled.input`
+  border: none;
+  padding: 0.5rem;
+  margin: 0.1rem;
+  outline: none;
+`;
+export const InfoTextarea = styled.textarea`
+  width: 100%;
+  border: none;
+  padding: 0.5rem;
+  margin: 0.1rem;
+  outline: none;
+`;
+export const NameInput = styled(InfoInput)`
+  font-size: 1.2rem;
+  font-weight: 500;
+  display: block;
+`;
+export const RadioContainer = styled.div`
+  display: flex;
+`;
+export const Item = styled.div`
+  display: flex;
+  margin-left: 0.2rem;
+  align-items: center;
+  position: relative;
+  box-sizing: border-box;
+`;
+export const RadioButtonLabel = styled.label`
+  position: absolute;
+  top: 21%;
+  left: 10px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background-color: ${(props) => props.theme.palette.lightgray};
+`;
+export const RadioButton = styled.input`
+  opacity: 0;
+  z-index: 1;
+  cursor: pointer;
+  width: 25px;
+  height: 25px;
+  &:hover ~ ${RadioButtonLabel} {
+    background-color: ${(props) => props.theme.palette.orange};
+    opacity: 0.5;
+  }
+  &:checked + ${RadioButtonLabel} {
+    border: none;
+    background-color: ${(props) => props.theme.palette.orange};
+  }
+`;
+export const RadioText = styled.p`
+  font-size: 0.9rem;
+  margin-left: 0.4rem;
+`;

--- a/client/src/pages/pet-information/PetInformation.tsx
+++ b/client/src/pages/pet-information/PetInformation.tsx
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+import PetCard from "./PetCard";
+import { MainContainer, AddBtn } from "./PetInfoStyle";
+import AddPet from "./AddPet";
+
+const token = localStorage.getItem("token");
+function PetInformation() {
+  const [pets, setPets] = useState();
+  const [isOpen, setIsOpen] = useState<boolean>(true);
+  // 처음 한 번만 서버 통신
+  useEffect(() => {
+    axios
+      .get("http://localhost:5100/pet/mypets", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      .then((res) => {
+        console.log(res.data);
+      });
+  }, []);
+  return (
+    <MainContainer>
+      <h1>pet info</h1>
+      <AddBtn>
+        <i className="fa-solid fa-plus fa-xl"></i>
+      </AddBtn>
+      {isOpen && <AddPet />}
+      <PetCard />
+    </MainContainer>
+  );
+}
+
+export default PetInformation;


### PR DESCRIPTION
## 📑 제목
디자인 틀 재구성
<img width="861" alt="스크린샷 2022-07-17 오전 2 41 21" src="https://user-images.githubusercontent.com/82802784/179366168-0a38fa06-a937-482a-8c50-92f15f8835ee.png">
펫 정보 불러오기 확인
<img width="454" alt="스크린샷 2022-07-17 오전 2 41 38" src="https://user-images.githubusercontent.com/82802784/179366187-985fb851-3b45-4796-9aad-a0ccb9911235.png">


## 📎 관련 이슈
closes #165

## ✔️ 셀프 체크리스트
- [v ] Warning Message가 발생하지 않았나요?
- [ v] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
디자인 틀 재구성
서버 통신 확인
 
## 🚧 PR 특이 사항
[[FE] 펫 정보 페이지]-[디자인]-[기초 디자인]
[[FE] 펫 정보 페이지]-[메인컴포넌트]-[apu 구현 후 펫 crud]

추후 펫을 추가하는 컴포넌트를 추가하고 펫 정보를 등록하는 기능을 구현할 예정

## 🕰 실제 소요 시간
3h
