### PR TITLE
feature/#212: 관리자 병원리스트 조회

### DIFF
--- a/server/src/db/models/HospModel.ts
+++ b/server/src/db/models/HospModel.ts
@@ -67,6 +67,21 @@ export interface ToUpdate {
   };
 }
 
+export interface ToUpdateByName {
+  hospitalName: string;
+  update: {
+    [key: string]:
+      | string
+      | number
+      | Address
+      | addressCoordinate
+      | number[]
+      | string[]
+      | object[]
+      | mongoose.Types.ObjectId;
+  };
+}
+
 export interface HospitalInfoRequired {
   hospitalId: string;
   currentPassword: string;
@@ -128,6 +143,21 @@ export class HospitalModel {
     return updatedHospital;
   }
 
+  async updateByName(
+    hospitalName: string,
+    update: Partial<HospitalInfo>
+  ): Promise<HospitalInfo> {
+    const filter = { name: hospitalName };
+    const option = { returnOriginal: false };
+
+    const updatedHospital = (await Hospital.findOneAndUpdate(
+      filter,
+      update,
+      option
+    )) as HospitalInfo;
+    return updatedHospital;
+  }
+
   async countHospitals(searchOptions: SearchOptions): Promise<number> {
     const counts = await Hospital.countDocuments(searchOptions);
     return counts;
@@ -151,6 +181,32 @@ export class HospitalModel {
       hospRegStatus: 0,
       createdAt: 0,
       updatedAt: 0,
+      __v: 0,
+    })
+      .sort({ createdAt: -1 })
+      .skip(perPage * (page - 1))
+      .limit(perPage)) as HospitalInfo[];
+    return users;
+  }
+
+  async findByOptionFromAdmin(
+    page: number,
+    perPage: number,
+    searchOptions: SearchOptions
+  ): Promise<HospitalInfo[]> {
+    const users = (await Hospital.find(searchOptions, {
+      _id: 0,
+      director: 0,
+      password: 0,
+      addressCoordinate: 0,
+      businessHours: 0,
+      holiday: 0,
+      hospitalCapacity: 0,
+      tag: 0,
+      keyword: 0,
+      image: 0,
+      refreshToken: 0,
+      starRating: 0,
       __v: 0,
     })
       .sort({ createdAt: -1 })

--- a/server/src/routers/HospRouter.ts
+++ b/server/src/routers/HospRouter.ts
@@ -642,6 +642,51 @@ hospitalRouter.get('/list/main', async (req, res, next) => {
   }
 });
 
+//pagination 변수
+//page : 현재 페이지
+//perPage : 페이지 당 게시글개수
+hospitalRouter.get('/admin/list/', async (req, res, next) => {
+  try {
+    const page = Number(req.query.page || 1);
+    const perPage = Number(req.query.perPage || 10);
+
+    let searchOptions = {};
+    if (req.query.option == 'name') {
+      searchOptions = { name: req.query.content };
+    } else if (req.query.option == 'hospStatus') {
+      searchOptions = { hospStatus: req.query.content };
+    } else if (req.query.option == 'hospRegStatus') {
+      searchOptions = { hospRegStatus: req.query.content };
+    }
+
+    const totalHospitals = await hospitalService.countTotalHospitals(
+      searchOptions
+    );
+
+    const hospitals = await hospitalService.getHospitalsByAdmin(
+      page,
+      perPage,
+      searchOptions
+    );
+
+    const totalPage = Math.ceil(totalHospitals / perPage);
+
+    res.status(200).json({
+      data: {
+        searchOptions: searchOptions,
+        hospitals: hospitals,
+        page: page,
+        perPage: perPage,
+        totalPage: totalPage,
+        totalHospitals: totalHospitals,
+      },
+      message: '',
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
 hospitalRouter.get('/detail', HospLoginRequired, async (req, res, next) => {
   try {
     const hospInfo = await hospitalService.findHospitalByName(

--- a/server/src/services/HospService.ts
+++ b/server/src/services/HospService.ts
@@ -252,6 +252,19 @@ class HospitalService {
     );
     return users;
   }
+
+  async getHospitalsByAdmin(
+    page: number,
+    perPage: number,
+    searchOptions: SearchOptions
+  ): Promise<HospitalInfo[]> {
+    const users = await this.hospitalModel.findByOptionFromAdmin(
+      page,
+      perPage,
+      searchOptions
+    );
+    return users;
+  }
 }
 
 const hospitalService = new HospitalService(hospitalModel);


### PR DESCRIPTION
## 📑 제목
관리자 병원 전체 정보 조회 API - (병원등록상태/병원상태/병원이름)으로 필터 및 페이지네이션 구현

## 📎 관련 이슈
closes #212 

## ✔️ 셀프 체크리스트
- [v] Warning Message가 발생하지 않았나요?
- [v] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
관리자 병원 전체 정보 조회 API - (병원등록상태/병원상태/병원이름)으로 필터 및 페이지네이션
 
## 🚧 PR 특이 사항
[[BE] 관리자 유저 정보 / 병원 페이지]-[API]-[관리자 병원 전체 정보 조회 API]

## 🕰 실제 소요 시간
1h
