### PR TITLE
feature/#214: 일반 유저 role과 status recoil에 담기

### DIFF
--- a/client/src/pages/login/LoginLayout.tsx
+++ b/client/src/pages/login/LoginLayout.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
+import React, { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
 
 import {
   LoginWrapper,
@@ -11,11 +11,12 @@ import {
   PasswordInput,
   UserCheckBox,
   UserInput,
-} from './LoginStyle';
+} from "./LoginStyle";
 
-import { CustomAxiosPost } from '../../common/CustomAxios';
-import { useRecoilState } from 'recoil';
-import { hospitalLoginState, THospital } from '../../state/HospitalState';
+import { CustomAxiosPost } from "../../common/CustomAxios";
+import { useRecoilState } from "recoil";
+import { hospitalLoginState, THospital } from "../../state/HospitalState";
+import { TUser, userState } from "../../state/UserState";
 
 type LoginState = {
   email: string;
@@ -26,11 +27,12 @@ function LoginLayout() {
   const navigate = useNavigate();
   const [isCheckUser, setIsCheckUser] = useState<boolean>(false);
   const [logins, setLogins] = useState<LoginState>({
-    email: '',
-    password: '',
+    email: "",
+    password: "",
   });
   // 병원 상태 저장!
   const [hospital, setHospital] = useRecoilState<THospital>(hospitalLoginState);
+  const [user, setUser] = useRecoilState<TUser>(userState);
 
   // 비구조화 할당으로 email , password 값을 추출한다.
   const { email, password } = logins;
@@ -49,22 +51,28 @@ function LoginLayout() {
     // 만일 일반 유저가 로그인 했다면
     if (!isCheckUser) {
       try {
-        const result = await CustomAxiosPost.post('/api/login', logins);
-        const token: string = result.data.userToken.token;
+        const result = await CustomAxiosPost.post("/api/login", logins);
+        const { token, role, userStatus } = result.data.userToken;
+        setUser({
+          ...user,
+          role,
+          userStatus,
+        });
+
         // 만일 토큰이 존재하면 로그인에 성공한거니까 access 토큰을 storage에 저장한후에 로그인 성공 메시지 남기고 페이지 이동
         if (token) {
-          localStorage.setItem('token', token);
-          alert('로그인에 성공하였습니다.');
-          navigate('/');
+          localStorage.setItem("token", token);
+          alert("로그인에 성공하였습니다.");
+          navigate("/");
         }
       } catch (e) {
-        alert('아이디 또는 비밀번호 오류입니다.');
+        alert("아이디 또는 비밀번호 오류입니다.");
       }
     } else {
       // 만일 병원 유저가 로그인 했다면
       try {
         const hospitalUser = await CustomAxiosPost.post(
-          '/hospital/login',
+          "/hospital/login",
           logins
         );
         const { hospitalName, hospitalState } = hospitalUser.data.data;
@@ -74,17 +82,17 @@ function LoginLayout() {
           hospitalName,
           hospitalState,
         });
-        if (hospitalState === '추가정보 미기입') {
-          alert('추가정보를 기입해주세요.');
-          navigate('/hospital-info');
+        if (hospitalState === "추가정보 미기입") {
+          alert("추가정보를 기입해주세요.");
+          navigate("/hospital-info");
           return;
         }
         alert(`로그인에 성공하였습니다.`);
-        navigate('/');
+        navigate("/");
       } catch (e: any) {
         const errorMsg = e.response.data.message;
         // errorMsg가 확인중일때는 아래와 같은 경고창을 띄워준다.
-        if (errorMsg === '확인중') {
+        if (errorMsg === "확인중") {
           alert(`관리자 승인 대기중입니다. \n승인 완료시까지 기다려주세요.`);
         }
       }
@@ -128,14 +136,14 @@ function LoginLayout() {
           onClick={handleLoginChecked}
           variant="contained"
           type="submit"
-          sx={{ mb: 1, bgcolor: '#F87474' }}
+          sx={{ mb: 1, bgcolor: "#F87474" }}
         >
           로그인
         </LoginButton>
         <KakaoButton
           variant="contained"
           type="submit"
-          sx={{ mb: 1, bgcolor: '#fae100', color: 'black' }}
+          sx={{ mb: 1, bgcolor: "#fae100", color: "black" }}
         >
           카카오 로그인
         </KakaoButton>

--- a/client/src/state/UserState.tsx
+++ b/client/src/state/UserState.tsx
@@ -1,0 +1,14 @@
+import { atom } from "recoil";
+
+export type TUser = {
+  role: string;
+  userStatus: string;
+};
+
+export const userState = atom<TUser>({
+  key: "userState",
+  default: {
+    role: "",
+    userStatus: "",
+  },
+});


### PR DESCRIPTION
## 📑 제목
<img width="374" alt="스크린샷 2022-07-19 오후 11 50 47" src="https://user-images.githubusercontent.com/76891694/179781359-03e0be01-0dfd-4c85-a71c-3f0c60fa0332.png">


## 📎 관련 이슈
closes #214 

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
일반 유저 login시 role과 status를 recoil에 담았습니다. 
 
## 🚧 PR 특이 사항

[[FE] 로그인 화면]-[라우팅]-[유저 role과 state를 recoil에 담아서 관리]

## 🕰 실제 소요 시간
0.5h