### PR TITLE
feature/#238: 예약페이지 모달창 틀 완성

### DIFF
--- a/client/src/components/ModalStyle.tsx
+++ b/client/src/components/ModalStyle.tsx
@@ -8,6 +8,6 @@ export const ModalStyle = {
     height: "600px",
     padding: "0",
     margin: "auto",
-    overflow: "hidden",
+    overflow: "auto",
   },
 };

--- a/client/src/components/book/ReservationContent.tsx
+++ b/client/src/components/book/ReservationContent.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Container, InfoInput, InputLabel } from "../InfoForm";
+
+type TBookProps = {
+  label: string;
+  defaultValue: string;
+  name: string;
+};
+
+const ReservationContent = ({ label, defaultValue, name }: TBookProps) => {
+  return (
+    <Container>
+      <InputLabel>{label}</InputLabel>
+      <InfoInput defaultValue={defaultValue} />
+    </Container>
+  );
+};
+
+export default ReservationContent;

--- a/client/src/components/book/ReservationModalForm.tsx
+++ b/client/src/components/book/ReservationModalForm.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from "react";
+import Modal from "react-modal";
+import { ModalStyle } from "../ModalStyle";
+import styled from "styled-components";
+import ReservationContent from "./ReservationContent";
+import MenuItem from "@mui/material/MenuItem";
+import Select from "@mui/material/Select";
+import { InfoBtn } from "../InfoForm";
+import { Link } from "react-router-dom";
+
+const ReservationTitle = styled.h2`
+  text-align: center;
+`;
+const ReservationWrapper = styled.div`
+  margin: 20px;
+`;
+const ReservationSubTitle = styled.h3``;
+
+const ModalCloseBtn = styled(InfoBtn)`
+  margin-left: 10px;
+`;
+const ModalModifyBtn = styled(InfoBtn)``;
+const ModalBtnContainer = styled.div`
+  margin-top: 20px;
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const ReservationModalForm = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const isToken = localStorage.getItem("token");
+
+  const handleChangeModalState = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div>
+      <Modal isOpen={isOpen} style={ModalStyle} ariaHideApp={false}>
+        <ReservationWrapper>
+          <ReservationTitle>예약 정보 조회</ReservationTitle>
+          <ReservationSubTitle>펫 정보</ReservationSubTitle>
+          {/* TODO: 이거 뭔가 너무 징그러운데 어케 좋은 방법 있을까요?? API가 있으면 중복적으로 처리하지 않아도 되려나요??*/}
+          {/* 아니면 펫정보부분 따로 컴포넌트화 시키고 서비스 부분 따로 컴포넌트화 시키고 상태부분 따로 컴포넌트화 시킬까요?? */}
+          <ReservationContent label="종" defaultValue="강아지" name="species" />
+          <ReservationContent
+            label="품종"
+            defaultValue="포메라니안"
+            name="breed"
+          />
+          <ReservationContent label="이름" defaultValue="모모" name="name" />
+          <ReservationContent label="나이" defaultValue="35" name="age" />
+          <ReservationContent label="성별" defaultValue="남" name="sex" />
+          <ReservationContent label="무게" defaultValue="3kg" name="weight" />
+          <ReservationContent
+            label="진료 내역"
+            defaultValue="중성화 수술"
+            name="medicalHistory"
+          />
+          <ReservationContent
+            label="접종 내역"
+            defaultValue="모름"
+            name="vaccination"
+          />
+          <ReservationSubTitle>서비스</ReservationSubTitle>
+          <ReservationContent
+            label="예약 날짜"
+            defaultValue="2022년 7월 20일"
+            name="reservationDate"
+          />
+          <ReservationContent
+            label="진료 항목"
+            defaultValue="중성화 수술"
+            name="clinic"
+          />
+          <ReservationContent
+            label="가격"
+            defaultValue="20000원"
+            name="price"
+          />
+          <ReservationSubTitle>상태</ReservationSubTitle>
+          <Select
+            labelId="demo-simple-select-label"
+            id="demo-simple-select"
+            defaultValue=""
+            sx={{ width: 150 }}
+            label="Age"
+          >
+            <MenuItem value={10}>예약 완료</MenuItem>
+            <MenuItem value={20}>예약 취소</MenuItem>
+            <MenuItem value={30}>예약 대기</MenuItem>
+            <MenuItem value={40}>예약 확정</MenuItem>
+          </Select>
+          <ModalBtnContainer>
+            {isToken && (
+              <Link to="/user-info">
+                <ModalModifyBtn>수정</ModalModifyBtn>
+              </Link>
+            )}
+            <ModalCloseBtn onClick={handleChangeModalState}>닫기</ModalCloseBtn>
+          </ModalBtnContainer>
+        </ReservationWrapper>
+      </Modal>
+      <button onClick={handleChangeModalState}>조회</button>
+    </div>
+  );
+};
+
+export default ReservationModalForm;


### PR DESCRIPTION
## 📑 제목
<img width="720" alt="스크린샷 2022-07-20 오후 11 32 27" src="https://user-images.githubusercontent.com/76891694/180012421-c2e32259-a3ac-46e4-83ec-886695c2c2ae.png">
<img width="592" alt="스크린샷 2022-07-20 오후 11 32 38" src="https://user-images.githubusercontent.com/76891694/180012433-56b9ced7-d300-4682-b70d-eaa8bb97d687.png">


## 📎 관련 이슈
closes #238 

## ✔️ 셀프 체크리스트
- [x] Warning Message가 발생하지 않았나요?
- [x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
예약 페이지에서 공통으로 사용할 모달창 틀을 만들어놨는데 사용하실때 약간씩 변경해서 사용하셔야 할 것 같습니다.
디자인도 바꾸셔도 되니까 편하게 사용해주세요!
+ 모달창에 overflow 속성을 변경하였습니다. 
 
## 🚧 PR 특이 사항

[[FE] 관리자 모든 예약 페이지]-[디자인]-[기초 디자인]

## 🕰 실제 소요 시간
2h