### PR TITLE
feature/#261 예약 조회 리스트에서 펫 정보 삭제당했을 때 빈 값으로 펫 정보 제공

### DIFF
--- a/server/src/routers/RezRouter.ts
+++ b/server/src/routers/RezRouter.ts
@@ -140,7 +140,7 @@ reservationRouter.get(
       const customerIds = Reservations.map((data) => data.customer.toString());
       const petIds = Reservations.map((data) => data.pet.toString());
       const rezStatuses = Reservations.map((data) => data.rezStatus.toString());
-
+      console.log(petIds);
       const customerInfoes = await userService.findByIds(customerIds);
       const petInfoes = await petService.findByIds(petIds);
       const rezStatusInfoes = await rezStatusService.findByIds(rezStatuses);

--- a/server/src/services/PetService.ts
+++ b/server/src/services/PetService.ts
@@ -1,4 +1,5 @@
 import { PetData, PetInfo, petModel, PetModel } from '../db';
+import mongoose, { model } from 'mongoose';
 
 interface PetInfoRequired {
   owner: string;
@@ -92,12 +93,26 @@ class PetService {
   // 펫 ID 배열에 담긴 것들을 조회
   async findByIds(petIds: string[]): Promise<PetData[]> {
     const petInfoes: PetData[] = [];
-    console.log(petIds);
+    console.log('펫아이디느ㅜㄴ?', petIds);
     for (let petId of petIds) {
-      const petInfo = await this.petModel.findByPetId(petId);
+      console.log(petId);
+      let petInfo = await this.petModel.findByPetId(petId);
       console.log(petInfo);
       if (!petInfo) {
-        throw new Error('펫 정보를 찾을 수 없습니다. 다시 한번 확인해 주세요.');
+        petInfo = {
+          _id: new mongoose.Types.ObjectId(petId),
+          owner: '',
+          species: '',
+          breed: '',
+          name: '',
+          age: 0,
+          sex: '',
+          weight: 0,
+          medicalHistory: '',
+          vaccination: '',
+          neutralized: '',
+          image: '',
+        };
       }
 
       petInfoes.push(petInfo);


### PR DESCRIPTION
## 📑 제목
 예약 조회 리스트에서 펫 정보 삭제당했을 때 빈 값으로 펫 정보 제공

## 📎 관련 이슈
closes #261 

## ✔️ 셀프 체크리스트
- [v] Warning Message가 발생하지 않았나요?
- [v] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
구현 내용 및 작업 했던 내역  

petInfo = {
          _id: new mongoose.Types.ObjectId(petId),
          owner: '',
          species: '',
          breed: '',
          name: '',
          age: 0,
          sex: '',
          weight: 0,
          medicalHistory: '',
          vaccination: '',
          neutralized: '',
          image: '',
}
## 🚧 PR 특이 사항
- merge사유 : 에러사항 긴급 merge


## 🕰 실제 소요 시간
작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.  
0.2h