### PR TITLE
Feature/#323 관리자 유저 상태변경 및 ui 수정

### DIFF
--- a/client/src/pages/admin-userlist/UserCard.tsx
+++ b/client/src/pages/admin-userlist/UserCard.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import axios from 'axios';
 import {
   InfoCard,
   TextContainer,
@@ -8,12 +9,25 @@ import {
   Select,
 } from '../../components/Liststyle';
 function UserCard({ data }: any) {
+  const token = localStorage.getItem('token');
   const [status, setStatus] = useState<string>(data?.userStatus);
   useEffect(() => {
     setStatus(data?.userStatus);
   }, [data]);
+
   const onhandleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = event.target.value;
     setStatus(event.target.value);
+    const id = {
+      userId: data._id,
+      userStatus: value === 'normal' ? 'expired' : 'normal',
+    };
+
+    axios.patch(`http://localhost:5000/api/admin/status`, id, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
   };
 
   return (

--- a/client/src/pages/user-info/UserInfo.tsx
+++ b/client/src/pages/user-info/UserInfo.tsx
@@ -23,6 +23,8 @@ import { userState } from '../../state/UserState';
 import { hospitalLoginState } from '../../state/HospitalState';
 
 function UserInfo() {
+  console.log(111);
+
   const token = localStorage.getItem('token');
   const navigate = useNavigate();
   // 받아온 정보를 저장하는 state
@@ -47,6 +49,8 @@ function UserInfo() {
 
   // 처음 한 번만 서버 통신
   useEffect(() => {
+    console.log(222);
+
     axios
       .get('http://kdt-sw2-seoul-team14.elicecoding.com:5000/api/user', {
         headers: {


### PR DESCRIPTION
## 📑 제목
관리자 유저 상태변경 및 ui 수정
<img width="847" alt="스크린샷 2022-07-27 오후 3 40 41" src="https://user-images.githubusercontent.com/82802784/181178919-2f889d45-d7d5-458f-81bc-52776110c4d3.png">


## 📎 관련 이슈


## ✔️ 셀프 체크리스트
- [x ] Warning Message가 발생하지 않았나요?
- [ x] Coding Convention을 준수했나요?
- [ ] Test Code를 작성하였나요?
  
## 💬 작업 내용
관리자 유저 상태변경 및 ui 수정
 
## 🚧 PR 특이 사항
[[FE] 관리자 유저 정보 / 병원 페이지]-[메인 컴포넌트]-[유저/병원 db에서 모든 정보 받아오기]
진행을 위해 머지



## 🕰 실제 소요 시간
작업을 시작하기 부터 PR을 올리기 까지 소요된 시간입니다.  
1h
